### PR TITLE
Squash bug/CNC-249-composer.json-is-invalid-in-filecloud-php

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,15 +1,20 @@
 {
-    "name": "/",
-    "description": "",
+    "name": "cn-consult/filecloud-php",
+    "description": "The FileCloud API in an easy to use, swagger based PHP API.",
     "keywords": [
         "swagger",
         "php",
         "sdk",
-        "api"
+        "api",
+        "filecloud"
     ],
-    "homepage": "http://swagger.io",
+    "homepage": "http://www.cn-consult.eu",
     "license": "Apache-2.0",
     "authors": [
+        {
+            "name": "Pascal Stiemer",
+            "homepage": "https://github.com/PStiemer"
+        },
         {
             "name": "Swagger and contributors",
             "homepage": "https://github.com/swagger-api/swagger-codegen"


### PR DESCRIPTION
I received the following E-Mail from packagist.org:
![image](https://user-images.githubusercontent.com/13750648/44253259-52a3d080-a1ff-11e8-9fa8-3685b1e4ad64.png)


I added the informations that got lost in the last pull request and tested it with composer validate.
![image](https://user-images.githubusercontent.com/13750648/44253345-97c80280-a1ff-11e8-80b0-5ea65b78c701.png)

#CNC-249 work 3m